### PR TITLE
Add async def keyword

### DIFF
--- a/grammars/python.cson
+++ b/grammars/python.cson
@@ -512,7 +512,7 @@
     'captures':
       '1':
         'name': 'storage.type.function.python'
-    'match': '\\b(def|lambda)\\b'
+    'match': '\\b(def|lambda|async def)\\b'
   }
   {
     'captures':


### PR DESCRIPTION
Enable highlighting for `async def`.

`async` on its own should not be highlighted as it is still a valid identifier - therefore it is also not added to `illegal_names`.

Reference atom#93.
